### PR TITLE
feat: daily snapshot capture + open_issues/archived (feed-v2)

### DIFF
--- a/scripts/db_writer.py
+++ b/scripts/db_writer.py
@@ -76,19 +76,19 @@ def _upsert_repo(cur, repo: Dict, platform: str):
     cur.execute("""
         INSERT INTO repos (
             id, full_name, owner, name, owner_avatar_url, description,
-            default_branch, html_url, stars, forks, language,
+            default_branch, html_url, stars, forks, open_issues, language,
             topics, latest_release_date, latest_release_tag,
             has_installers_android, has_installers_windows,
             has_installers_macos, has_installers_linux,
-            download_count, trending_score, popularity_score,
-            created_at_gh, updated_at_gh, indexed_at
+            download_count, archived, trending_score, popularity_score,
+            created_at_gh, updated_at_gh, pushed_at_gh, indexed_at
         ) VALUES (
             %(id)s, %(full_name)s, %(owner)s, %(name)s, %(avatar)s, %(description)s,
-            %(default_branch)s, %(html_url)s, %(stars)s, %(forks)s, %(language)s,
+            %(default_branch)s, %(html_url)s, %(stars)s, %(forks)s, %(open_issues)s, %(language)s,
             %(topics)s, %(release_date)s, NULL,
             %(android)s, %(windows)s, %(macos)s, %(linux)s,
-            %(download_count)s, %(trending_score)s, %(popularity_score)s,
-            %(created_at)s, %(updated_at)s, NOW()
+            %(download_count)s, %(archived)s, %(trending_score)s, %(popularity_score)s,
+            %(created_at)s, %(updated_at)s, %(pushed_at)s, NOW()
         )
         ON CONFLICT (id) DO UPDATE SET
             full_name = EXCLUDED.full_name,
@@ -100,12 +100,15 @@ def _upsert_repo(cur, repo: Dict, platform: str):
             html_url = EXCLUDED.html_url,
             stars = EXCLUDED.stars,
             forks = EXCLUDED.forks,
+            open_issues = EXCLUDED.open_issues,
+            archived = EXCLUDED.archived,
             language = EXCLUDED.language,
             topics = EXCLUDED.topics,
             latest_release_date = COALESCE(EXCLUDED.latest_release_date, repos.latest_release_date),
             trending_score = COALESCE(EXCLUDED.trending_score, repos.trending_score),
             popularity_score = COALESCE(EXCLUDED.popularity_score, repos.popularity_score),
             updated_at_gh = EXCLUDED.updated_at_gh,
+            pushed_at_gh = COALESCE(EXCLUDED.pushed_at_gh, repos.pushed_at_gh),
             indexed_at = NOW(),
             has_installers_android = repos.has_installers_android OR EXCLUDED.has_installers_android,
             has_installers_windows = repos.has_installers_windows OR EXCLUDED.has_installers_windows,
@@ -123,10 +126,12 @@ def _upsert_repo(cur, repo: Dict, platform: str):
         "html_url": repo.get("htmlUrl"),
         "stars": repo.get("stargazersCount", 0),
         "forks": repo.get("forksCount", 0),
+        "open_issues": repo.get("openIssuesCount", 0),
         "language": repo.get("language"),
         "topics": repo.get("topics", []),
         "release_date": repo.get("latestReleaseDate"),
         "download_count": repo.get("downloadCount", 0),
+        "archived": repo.get("archived", False),
         "android": platform_flags["has_installers_android"],
         "windows": platform_flags["has_installers_windows"],
         "macos": platform_flags["has_installers_macos"],
@@ -135,7 +140,58 @@ def _upsert_repo(cur, repo: Dict, platform: str):
         "popularity_score": repo.get("popularityScore"),
         "created_at": repo.get("createdAt"),
         "updated_at": repo.get("updatedAt"),
+        "pushed_at": repo.get("pushedAt") or None,
     })
+
+
+def save_daily_snapshot():
+    """Append one row per repo to repo_daily_snapshot for today (UTC).
+
+    Catalog-wide INSERT...SELECT straight off the `repos` table — zero extra
+    GitHub calls, captures the values the fetch just persisted, and is always
+    full-catalog regardless of which run triggers it. This is the velocity
+    time-series: GitHub exposes downloads only as a running total, so
+    day-over-day differencing of these rows is the ONLY way to compute
+    download velocity, and a missed day cannot be backfilled.
+
+    Idempotent per UTC day via ON CONFLICT DO UPDATE (last write of the day
+    wins), so re-running the same day refreshes rather than errors. Velocity
+    EWMA columns are left NULL; the backend VelocityAggregationWorker fills them.
+
+    Intended to run from the daily 02:00 UTC full fetch. Gated by the
+    CAPTURE_DAILY_SNAPSHOT env (default on) so a lighter intra-day run can opt
+    out and keep day-over-day deltas comparing full-catalog like-for-like.
+    """
+    if os.environ.get("CAPTURE_DAILY_SNAPSHOT", "1") not in ("1", "true", "True"):
+        print("  ⓘ daily snapshot skipped (CAPTURE_DAILY_SNAPSHOT disabled)")
+        return
+    conn = _get_connection()
+    if conn is None:
+        return
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    INSERT INTO repo_daily_snapshot
+                        (repo_id, snapshot_date, stars, download_count,
+                         forks, open_issues, latest_release_date)
+                    SELECT id, (NOW() AT TIME ZONE 'UTC')::date, stars, download_count,
+                           forks, open_issues, latest_release_date
+                    FROM repos
+                    ON CONFLICT (repo_id, snapshot_date) DO UPDATE SET
+                        stars = EXCLUDED.stars,
+                        download_count = EXCLUDED.download_count,
+                        forks = EXCLUDED.forks,
+                        open_issues = EXCLUDED.open_issues,
+                        latest_release_date = EXCLUDED.latest_release_date,
+                        captured_at = NOW()
+                """)
+                count = cur.rowcount
+        print(f"  ✓ daily snapshot: {count} repos captured for today (UTC)")
+    except Exception as e:
+        print(f"  ✗ daily snapshot error: {e}", file=sys.stderr)
+    finally:
+        conn.close()
 
 
 def _update_categories(cur, category: str, platform: str, repos: List[Dict]):

--- a/scripts/fetch_all_categories.py
+++ b/scripts/fetch_all_categories.py
@@ -27,9 +27,10 @@ from typing import List, Dict, Optional, Tuple, Set
 from dataclasses import dataclass, field
 
 try:
-    from db_writer import save_to_postgres
+    from db_writer import save_to_postgres, save_daily_snapshot
 except ImportError:
     save_to_postgres = None
+    save_daily_snapshot = None
 
 # ─── Configuration ────────────────────────────────────────────────────────────
 
@@ -180,11 +181,15 @@ class RepoCandidate:
     releases_url: str
     updated_at: str
     created_at: str
+    # R5/R13: last default-branch commit (GitHub pushed_at), distinct from updated_at.
+    pushed_at: Optional[str] = None
     score: int = 0
     has_installers: bool = False
     recent_stars_velocity: float = 0.0
     latest_release_date: Optional[str] = None
     download_count: int = 0
+    open_issues: int = 0
+    archived: bool = False
 
     def to_summary(self, category: str = "trending") -> Dict:
         base = {
@@ -202,7 +207,10 @@ class RepoCandidate:
             "releasesUrl": self.releases_url,
             "updatedAt": self.updated_at,
             "createdAt": self.created_at,
+            "pushedAt": self.pushed_at,
             "downloadCount": self.download_count,
+            "openIssuesCount": self.open_issues,
+            "archived": self.archived,
         }
 
         if self.latest_release_date:
@@ -530,6 +538,9 @@ def make_candidate(repo: Dict, platform: str, velocity: float = 0.0, score_weigh
         releases_url=repo["releases_url"],
         updated_at=repo["updated_at"],
         created_at=repo["created_at"],
+        pushed_at=repo.get("pushed_at"),
+        open_issues=repo.get("open_issues_count", 0),
+        archived=repo.get("archived", False),
         score=score,
         recent_stars_velocity=velocity,
     )
@@ -1391,6 +1402,12 @@ async def main():
             print("  ⚠ No tokens with enough budget for topics — skipping")
     else:
         print("\n⚠ No token available for topics — set GH_TOKEN_TOPICS or GITHUB_TOKEN")
+
+    # Daily velocity time-series capture — runs after the full catalog has been
+    # upserted so the snapshot reflects this run's fresh values. Reads straight
+    # off `repos`, so it is full-catalog and costs zero GitHub calls.
+    if save_daily_snapshot is not None:
+        save_daily_snapshot()
 
     elapsed = time.time() - start
     print(f"\n{'='*70}")


### PR DESCRIPTION
Feeds the backend feed-v2 velocity time-series. Pairs with backend Phase-0 migrations (V19/V20).

## Changes
1. **Persist open_issues + archived** on every repo upsert. GitHub's repo JSON already carries `open_issues_count` + `archived`; `_upsert_repo` now writes both, and RepoCandidate/to_summary surface them. `archived` = the feed-v2 quality-gate flag; `open_issues` unlocks dashboard charts. Neither was captured before — and a time-series gap can't be backfilled, so this lands WITH the snapshot.
2. **save_daily_snapshot()** — after the full catalog upsert in `main()`, one catalog-wide `INSERT...SELECT` off `repos` into `repo_daily_snapshot` (one row/repo/UTC-day). Zero extra GitHub calls, always full-catalog, idempotent per UTC day (ON CONFLICT DO UPDATE). Gated by `CAPTURE_DAILY_SNAPSHOT` (default on) so a lighter intra-day run can opt out.

Velocity (stars/day, downloads/day) is derived by differencing these rows — GitHub gives downloads only as a running total, so this is the only source. EWMA columns filled later by the backend worker.

## Requires
Backend migrations V19/V20 deployed first (repo_daily_snapshot, repos.archived). `py_compile` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily repository snapshots to track repository state changes over time.
  * Enhanced repository metadata collection to capture and monitor open issue counts, archive status, and last push timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->