### PR TITLE
fix: backfill never lowers download_count (monotonic contract)

### DIFF
--- a/scripts/backfill_downloads.py
+++ b/scripts/backfill_downloads.py
@@ -114,7 +114,13 @@ def get_total_downloads(full_name, token):
     pages = 0
     while url and pages < MAX_PAGES_PER_REPO:
         releases, next_url = github_request(url, token)
-        if not releases or not isinstance(releases, list):
+        # github_request returns body=None ONLY on a failed request (vs an empty
+        # list for a repo with no releases). A failure mid-pagination would
+        # otherwise return a partial/0 total that clobbers a good count — so
+        # signal it with None and let the caller skip the write entirely.
+        if releases is None:
+            return None, pages
+        if not isinstance(releases, list):
             break
         pages += 1
         for release in releases:
@@ -145,10 +151,24 @@ def _process_repo(repo, total_repos):
     downloads, pages = get_total_downloads(repo["full_name"], _local.token)
     elapsed = time.time() - t0
 
+    # Fetch failed (transient error / rate limit) — do NOT write. Writing the
+    # partial/0 would clobber the existing good count. Skip; still count the
+    # repo as processed so progress + page totals stay accurate.
+    if downloads is None:
+        with _lock:
+            _updated += 1
+            _total_pages += pages
+            current = _updated
+        print(f"  [skip] {repo['full_name']}: download fetch failed, keeping existing count", flush=True)
+        return
+
+    # GREATEST guards the monotonic contract even for a page-cap-truncated
+    # partial — a backfill can only ever raise download_count, never lower it,
+    # matching the fetcher's db_writer upsert.
     with _local.conn:
         with _local.conn.cursor() as cur:
             cur.execute(
-                "UPDATE repos SET download_count = %s WHERE id = %s",
+                "UPDATE repos SET download_count = GREATEST(%s, download_count) WHERE id = %s",
                 (downloads, repo["id"])
             )
 


### PR DESCRIPTION
CodeRabbit Major on #3, fixed on its own branch (the backfill script is already on main via #2).

A failed `github_request` returns `(None, None)`; `get_total_downloads` conflated that with an empty release list and returned 0/partial, which `_process_repo` wrote **directly** to Postgres + Meili — clobbering a good `download_count` and bypassing the fetcher's `GREATEST` contract. A transient rate-limit could zero out real counts across the catalog.

- `get_total_downloads` now returns `None` (≠ 0) on a page-request failure, so a real-0 repo and a fetch failure are distinct.
- `_process_repo` skips the write when `None` (keeps existing count), and the write uses `GREATEST(%s, download_count)` so even a page-cap partial can only raise, never lower.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download count accuracy by preventing partial or truncated values from being saved as final results.
  * Download counts are now only increased, never overwritten with lower values, preserving historical data.
  * Enhanced error handling to distinguish between data retrieval failures and repositories legitimately having no releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->