### PR TITLE
ci: auto-deploy fetcher scripts to the VPS on push to main

### DIFF
--- a/.github/workflows/deploy_fetcher.yml
+++ b/.github/workflows/deploy_fetcher.yml
@@ -1,0 +1,73 @@
+name: Deploy fetcher to production
+
+on:
+  # Auto-deploy whenever main moves (PR merge, direct admin commit) and the
+  # fetcher scripts changed. The cron launchers (run_*.sh) that invoke these
+  # live on the VPS, not in the repo, so a code push is all that needs syncing.
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/**'
+      - '.github/workflows/deploy_fetcher.yml'
+  # Manual button for break-glass redeploys / first-time setup.
+  workflow_dispatch:
+
+# One fetcher deploy at a time; queue, don't cancel (a half-synced scripts dir
+# mid-cron-run would be worse than waiting).
+concurrency:
+  group: deploy-fetcher
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure SSH
+        env:
+          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_KNOWN_HOSTS: ${{ secrets.DEPLOY_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$DEPLOY_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "$DEPLOY_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Sync scripts to /opt/fetcher
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          # NO --delete: the VPS-only cron launchers (run_fetcher.sh,
+          # run_new_releases.sh, run_backfill.sh) are not in the repo, so
+          # --delete would remove them and break the cron jobs. Flatten
+          # scripts/ -> /opt/fetcher/ (the prod layout has the .py files at the
+          # top level, not under scripts/).
+          rsync -avz \
+            --exclude '__pycache__/' \
+            --exclude '*.pyc' \
+            scripts/ "$DEPLOY_USER@$DEPLOY_HOST:/opt/fetcher/"
+
+      - name: Verify snapshot-capture code landed
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          # Fail loudly if the file that captures repo_daily_snapshot did not
+          # make it (e.g. a stale rsync) — that's the exact gap this workflow
+          # exists to close.
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" '
+            set -euo pipefail
+            grep -q save_daily_snapshot /opt/fetcher/fetch_all_categories.py
+            grep -q save_daily_snapshot /opt/fetcher/db_writer.py
+            echo "snapshot-capture present on /opt/fetcher"
+          '

--- a/.github/workflows/deploy_fetcher.yml
+++ b/.github/workflows/deploy_fetcher.yml
@@ -29,6 +29,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # No repo token needed — this deploy authenticates over SSH, so don't
+          # leave GITHUB_TOKEN in .git/config (zizmor artipacked).
+          persist-credentials: false
 
       - name: Configure SSH
         env:
@@ -63,11 +67,12 @@ jobs:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
         run: |
           # Fail loudly if the file that captures repo_daily_snapshot did not
-          # make it (e.g. a stale rsync) — that's the exact gap this workflow
-          # exists to close.
-          ssh "$DEPLOY_USER@$DEPLOY_HOST" '
-            set -euo pipefail
-            grep -q save_daily_snapshot /opt/fetcher/fetch_all_categories.py
-            grep -q save_daily_snapshot /opt/fetcher/db_writer.py
-            echo "snapshot-capture present on /opt/fetcher"
-          '
+          # make it (e.g. a stale rsync) — the exact gap this workflow closes.
+          # Portable && chain: the step fails if either grep misses, without
+          # relying on the remote login shell supporting `set -o pipefail` (it
+          # may be dash/sh); the echo runs only when both greps pass, so the
+          # step can't falsely succeed.
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            'grep -q save_daily_snapshot /opt/fetcher/fetch_all_categories.py \
+             && grep -q save_daily_snapshot /opt/fetcher/db_writer.py \
+             && echo "snapshot-capture present on /opt/fetcher"'


### PR DESCRIPTION
## Why

The fetcher at `/opt/fetcher` was hand-rsync'd **once in April and never updated**. So the daily-snapshot capture (`save_daily_snapshot`, merged in #3 on Jun 19 — the source of feed-v2 velocity **and** `dailyStars`) **never reached production**. `repo_daily_snapshot` is empty → no momentum ranking, and `/internal/run-daily-stars` returns `{filled:0}`.

There was **no CI deploy for the fetcher at all** (the backend's `deploy.yml` only syncs `/opt/github-store-backend`). This adds one.

## What

On push to `main` touching `scripts/**` (or manual dispatch): SSH-rsync `scripts/` → `/opt/fetcher/`, then verify `save_daily_snapshot` landed. Reuses the **same `DEPLOY_*` secrets** the backend deploy uses.

- **No `--delete`** — the cron launchers (`run_fetcher.sh`, `run_new_releases.sh`, `run_backfill.sh`) live only on the VPS, not in the repo; `--delete` would wipe them and break cron.
- **No rebuild** — plain Python run by cron, which picks up the new code on its next run.
- Flattens `scripts/` → `/opt/fetcher/` (prod has the `.py` at top level).
- A verify step `grep`s `save_daily_snapshot` on the box so a stale sync fails loudly.

## Required before this works (your side)

1. **Secrets** in this repo (or kurikomi-labs **org-level** so both repos inherit): `DEPLOY_SSH_KEY`, `DEPLOY_KNOWN_HOSTS`, `DEPLOY_HOST`, `DEPLOY_USER` — same values as `komi-store-backend`.
2. **One-time chown on the VPS** (the deploy user can't overwrite root-owned files — same bug as the backend deploy):
   ```bash
   chown -R <DEPLOY_USER> /opt/fetcher
   ```

## After merge

1. Run this workflow (or push) → fetcher code updated on the VPS.
2. Trigger the first capture so day-1 lands now instead of waiting for 02:00 cron:
   ```bash
   /opt/fetcher/run_fetcher.sh    # writes today's repo_daily_snapshot
   ```
3. Tomorrow's 02:00 run → day-2. Then `POST /internal/run-daily-stars` → `filled > 0`, and feed-v2 momentum comes alive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a GitHub Actions workflow to deploy the fetcher’s `scripts/` to the production server.
  * Deploys automatically on updates to the main branch (and workflow/scripting changes) and can also be run manually.
  * Ensures deployments don’t overlap by queuing runs.
  * Updated the deployment sync to preserve server-only files and only transfer repo scripts.
  * Added a post-deploy check to verify the expected snapshot logic is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->