### PR TITLE
fix(fetcher): exclude Alpine .apk from Android installer detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,11 +75,11 @@ cached-data/
 
 Each platform has: topics, installer file extensions, scoring keywords (high/medium/low), primary/secondary languages, and frameworks. See `PLATFORMS` dict.
 
-**Installer detection** — only dedicated installer file extensions count (generic archives like `.zip`/`.tar.gz` are ignored):
-- Android: `.apk`, `.aab`
-- Windows: `.msi`, `.exe`, `.msix`
+**Installer detection** — only client-installable file extensions count (generic archives like `.zip`/`.tar.gz` are ignored). These sets MUST stay byte-for-byte equivalent to the client's `core.domain.utils.AssetPlatform` + `isAssetInstallable`, else `has_installers_*` advertises what the client refuses to install:
+- Android: `.apk` **passing `is_android_apk`** — `.apk` is overloaded (nfpm/goreleaser emit Alpine Linux packages with it); a name-token discriminator (`linux`/`amd64`/`386` ⇒ NOT Android) is required. `.aab` is a Play Store bundle, not user-installable — excluded.
+- Windows: `.msi`, `.exe` (`.msix` excluded — client can't install it)
 - macOS: `.dmg`, `.pkg`
-- Linux: `.appimage`, `.deb`, `.rpm`
+- Linux: `.appimage`, `.deb`, `.rpm`, `.pkg.tar.zst` (Alpine `.apk` is NOT in the client's Linux set, so an Alpine-`.apk`-only repo is installable on nothing)
 
 ### Content Filtering
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Each category is fetched across 4 platforms:
 
 | Platform | Installer types | Primary languages |
 |---|---|---|
-| **Android** | `.apk`, `.aab` | Kotlin, Java |
-| **Windows** | `.exe`, `.msi`, `.msix` | C#, C++, Rust |
+| **Android** | `.apk` (Alpine `.apk` excluded via `is_android_apk`) | Kotlin, Java |
+| **Windows** | `.exe`, `.msi` | C#, C++, Rust |
 | **macOS** | `.dmg`, `.pkg` | Swift, Objective-C |
-| **Linux** | `.AppImage`, `.deb`, `.rpm` | C++, Rust, C |
+| **Linux** | `.AppImage`, `.deb`, `.rpm`, `.pkg.tar.zst` | C++, Rust, C |
 
 ## Requirements
 

--- a/scripts/fetch_all_categories.py
+++ b/scripts/fetch_all_categories.py
@@ -101,10 +101,25 @@ def _is_blocked(repo: Dict) -> bool:
 
 # ─── Platform definitions ─────────────────────────────────────────────────────
 
+# goreleaser/nfpm emit Alpine Linux packages with a `.apk` extension that are
+# NOT Android packages. An Alpine `.apk` always carries an OS / Go-arch token
+# (linux / amd64 / 386); a real Android APK never does. This discriminator must
+# stay byte-for-byte equivalent to the backend's AssetPlatform.isAndroidApk and
+# the client's core.domain.utils.isAndroidApk.
+_ALPINE_APK_RE = re.compile(r'(^|[^a-z0-9])(linux|amd64|386)([^a-z0-9]|$)')
+
+
+def is_android_apk(name: str) -> bool:
+    n = name.lower()
+    return n.endswith(".apk") and not _ALPINE_APK_RE.search(n)
+
+
 PLATFORMS = {
     "android": {
         "topics": ["android", "android-app", "kotlin-android"],
-        "installer_extensions": [".apk", ".aab"],
+        # Android installers are detected via is_android_apk (see _check_assets),
+        # not a plain suffix match — `.apk` alone over-matches Alpine packages.
+        "installer_extensions": [".apk"],
         "score_keywords": {
             "high": ["android", "kotlin-android"],
             "medium": ["mobile", "kotlin", "jetpack-compose"],
@@ -117,7 +132,7 @@ PLATFORMS = {
     },
     "windows": {
         "topics": ["windows", "electron", "desktop", "windows-app"],
-        "installer_extensions": [".msi", ".exe", ".msix"],
+        "installer_extensions": [".msi", ".exe"],
         "score_keywords": {
             "high": ["windows", "windows-app", "wpf", "winui"],
             "medium": ["desktop", "electron", "dotnet"],
@@ -139,7 +154,7 @@ PLATFORMS = {
     },
     "linux": {
         "topics": ["linux", "gtk", "qt", "gnome", "kde"],
-        "installer_extensions": [".appimage", ".deb", ".rpm"],
+        "installer_extensions": [".appimage", ".deb", ".rpm", ".pkg.tar.zst"],
         "score_keywords": {
             "high": ["linux", "gtk", "qt", "gnome"],
             "medium": ["desktop", "gnome", "kde", "flatpak"],
@@ -410,7 +425,11 @@ class GitHubClient:
                     continue
                 for asset in assets:
                     name = asset.get("name", "").lower()
-                    if any(name.endswith(ext) for ext in cfg["installer_extensions"]):
+                    if platform == "android":
+                        matched = is_android_apk(name)
+                    else:
+                        matched = any(name.endswith(ext) for ext in cfg["installer_extensions"])
+                    if matched:
                         info.has_installers[platform] = True
                         break
 


### PR DESCRIPTION
## Summary
`.apk` is overloaded — nfpm/goreleaser ship **Alpine Linux** packages with a `.apk` extension. The old `_check_assets` suffix match flagged them as `has_installers_android`, so Go CLIs like `go-task/task`, `authzed/spicedb`, `k8sgpt-ai/k8sgpt`, `txn2/kubefwd` were written with a bogus Android flag.

- Add `is_android_apk` + `_ALPINE_APK_RE` (byte-identical to the backend/client discriminator) and gate the `android` branch of `_check_assets` behind it.
- Align `PLATFORMS[*].installer_extensions` to the client contract: `.apk`-only Android, drop `.msix`, add `.pkg.tar.zst`.
- Monotonic `OR` accumulation in `db_writer` left intact (load-bearing for legit multi-platform repos).

This is the **daily primary writer** — without it, the catalog re-corrupts within ~1 day of any backend-only fix.

## Test plan
- [x] Discriminator verified: alpine names (`task_*_linux_amd64.apk`, `k8sgpt_amd64.apk`) → False; real Android (`app-arm64-v8a-release.apk`, `Magisk-v30.7.apk`, `v2rayNG_2.2.5_universal.apk`) → True.
- [x] `py_compile` clean.
- [ ] Next daily run no longer flags alpine-only repos as Android.

Paired with the backend classifier fix + `POST /internal/backfill-platforms` re-index (kurikomi-labs/komi-store-backend).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer detection to better distinguish Android APKs from similarly named Linux/Alpine packages.
  * Updated supported installer types so Android releases match APKs more reliably, Windows excludes MSIX, and Linux includes an additional package format.
  * Release asset verification now uses tighter matching rules, reducing incorrect installer classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->